### PR TITLE
Fix public IP service

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -124,8 +124,13 @@ novjccomp
 nologfd
 END
 
+apt-get -y install wget || {
+  echo "Could not install wget, required to retrieve your IP address." 
+  exit 1
+}
+
 #find out external ip 
-IP=`wget -q -O - http://ipecho.net/plain`
+IP=`wget -q -O - http://api.ipify.org`
 
 if [ "x$IP" = "x" ]
 then


### PR DESCRIPTION
The public IP service for `ipecho.net` has been unreachable, changed to `api.ipify.org` to fix the script.

Signed-off-by: Edwin Ang <edwin@theroyalstudent.me>